### PR TITLE
Link to the `sizes` parsing steps.

### DIFF
--- a/index.html
+++ b/index.html
@@ -203,7 +203,12 @@
           <ol>
             <li>Set |image|'s [=image resource/sizes=] to the result of parsing
             |input|.{{ImageResource/sizes}} as if it was a [^link/sizes^]
-            attribute. If parsing fails, throw a {{TypeError}}.
+            attribute of a [^link^] element whose [^link/rel^] attribute
+            contains the token `icon`. If parsing fails, throw a {{TypeError}}.
+              <div class="note"> The parsing steps are defined <a href=
+              "https://html.spec.whatwg.org/multipage/links.html#rel-icon">
+              here</a>. 
+              </div>
             </li>
           </ol>
         </li>
@@ -246,7 +251,12 @@
           <ol>
             <li>Set |image|'s [=image resource/sizes=] to the result of parsing
             |input|'s "sizes" property value as if it was a [^link/sizes^]
-            attribute. If parsing fails, return failure.
+            attribute of a [^link^] element whose [^link/rel^] attribute
+            contains the token `icon`. If parsing fails, throw a {{TypeError}}.
+              <div class="note"> The parsing steps are defined <a href=
+              "https://html.spec.whatwg.org/multipage/links.html#rel-icon">
+              here</a>. 
+              </div>
             </li>
           </ol>
         </li>

--- a/index.html
+++ b/index.html
@@ -201,15 +201,12 @@
         </li>
         <li>If |input|'s {{ImageResource/sizes}} member is present:
           <ol>
-            <li>Set |image|'s [=image resource/sizes=] to the result of parsing
-            |input|.{{ImageResource/sizes}} as if it was a [^link/sizes^]
-            attribute of a [^link^] element whose [^link/rel^] attribute
-            contains the token `icon`. If parsing fails, throw a {{TypeError}}.
-              <div class="note"> The parsing steps are defined <a href=
-              "https://html.spec.whatwg.org/multipage/links.html#rel-icon">
-              here</a>. 
-              </div>
-            </li>
+            <li>Set |image|'s [=image resource/sizes=] to the result of [=link
+              type "icon"|parsing=] |input|.{{ImageResource/sizes}} as if it
+              was a [^link/sizes^] attribute of a [^link^] element whose
+              [^link/rel^] attribute contains the token `icon`. If parsing
+              fails, throw a {{TypeError}}.
+              </li>
           </ol>
         </li>
         <li>If |input|'s {{ImageResource/type}} member is present and not the
@@ -249,14 +246,11 @@
         <li>If |input| has a "sizes" property and its type is a [=string=]
         of length greater than zero:
           <ol>
-            <li>Set |image|'s [=image resource/sizes=] to the result of parsing
-            |input|'s "sizes" property value as if it was a [^link/sizes^]
-            attribute of a [^link^] element whose [^link/rel^] attribute
-            contains the token `icon`. If parsing fails, return failure.
-              <div class="note"> The parsing steps are defined <a href=
-              "https://html.spec.whatwg.org/multipage/links.html#rel-icon">
-              here</a>. 
-              </div>
+            <li>Set |image|'s [=image resource/sizes=] to the result of [=link
+              type "icon"|parsing=] |input|.{{ImageResource/sizes}} as if it
+              was a [^link/sizes^] attribute of a [^link^] element whose
+              [^link/rel^] attribute contains the token `icon`. If parsing
+              fails, return failure.
             </li>
           </ol>
         </li>

--- a/index.html
+++ b/index.html
@@ -252,7 +252,7 @@
             <li>Set |image|'s [=image resource/sizes=] to the result of parsing
             |input|'s "sizes" property value as if it was a [^link/sizes^]
             attribute of a [^link^] element whose [^link/rel^] attribute
-            contains the token `icon`. If parsing fails, throw a {{TypeError}}.
+            contains the token `icon`. If parsing fails, return failure.
               <div class="note"> The parsing steps are defined <a href=
               "https://html.spec.whatwg.org/multipage/links.html#rel-icon">
               here</a>. 


### PR DESCRIPTION



<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/pull/19.html" title="Last updated on Apr 20, 2020, 12:52 PM UTC (dc0d353)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/19/414e2f3...dc0d353.html" title="Last updated on Apr 20, 2020, 12:52 PM UTC (dc0d353)">Diff</a>