### PR TITLE
An image resource might not contain sizes or type

### DIFF
--- a/index.html
+++ b/index.html
@@ -105,14 +105,14 @@
           <dfn data-dfn-for="image resource">sizes</dfn>
         </dt>
         <dd>
-          A [=string=] representing the sizes of the image, expressed using the
+          An optional [=string=] representing the sizes of the image, expressed using the
           same syntax as [^link^]'s [^link/sizes^] attribute.
         </dd>
         <dt>
           <dfn data-dfn-for="image resource">type</dfn>
         </dt>
         <dd>
-          An [=image MIME type=].
+          An optional [=image MIME type=].
         </dd>
       </dl>
       <p>


### PR DESCRIPTION
This matches the dictionary definition where only `src` is `required` and the "process an image resource from JSON" algorithm that doesn't fail on an absent `sizes` or `type`.


<!--
    This comment and the below content is programatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/jyasskin/image-resource/pull/33.html" title="Last updated on Feb 3, 2021, 12:21 AM UTC (6c4a551)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/33/8b317ff...jyasskin:6c4a551.html" title="Last updated on Feb 3, 2021, 12:21 AM UTC (6c4a551)">Diff</a>