### PR TITLE
Set fetch mode to cors for image resource fetching

### DIFF
--- a/index.html
+++ b/index.html
@@ -369,6 +369,8 @@
             <li>Set [=request/Client=] to the context object's [=relevant
             settings object=].
             </li>
+            <li>Set [=request/Mode=] to "[=cors=]".
+            </li>
           </ol>
         </li>
         <li>If |request|'s [=request/Client=] is null, throw a {{TypeError}}.
@@ -378,7 +380,9 @@
       </ol>
       <aside class="note">
         [=request/Client=] is required here so the appropriate CSP can be
-        applied.
+        applied. [=request/Mode=] is set to "[=cors=]" so that cross-origin
+        servers must explicitly opt-in to having their resources used as image
+        resources.
       </aside>
     </section>
     <section>

--- a/index.html
+++ b/index.html
@@ -355,7 +355,7 @@
         The steps for <dfn data-export="">fetching an image resource</dfn> are
         given by the following algorithm. The algorithm takes an [=image
         resource=] |image|, an optional [=Request=] |request|, and an optional
-        [=request/mode=] |mode| (default "`cors`"). It returns a
+        [=request/Mode=] |mode| (default "`cors`"). It returns a
         [=Response=].
       </p>
       <ol>

--- a/index.html
+++ b/index.html
@@ -355,11 +355,11 @@
         The steps for <dfn data-export="">fetching an image resource</dfn> are
         given by the following algorithm. The algorithm takes an [=image
         resource=] |image|, an optional [=Request=] |request|, and an optional
-        [=request/mode=] |mode| (default "[=cors=]"). It returns a
+        [=request/mode=] |mode| (default "`cors`"). It returns a
         [=Response=].
       </p>
       <ol>
-        <li>[=Assert=]: |mode| is "[=cors=]" or "[=same-origin=]".
+        <li>[=Assert=]: |mode| is "`cors`" or "`same-origin`".
         </li>
         <li>If |request| is `undefined`:
           <ol>
@@ -383,7 +383,7 @@
       </ol>
       <aside class="note">
         [=request/Client=] is required here so the appropriate CSP can be
-        applied. [=request/Mode=] is set to "[=cors=]" so that cross-origin
+        applied. [=request/Mode=] is set to "`cors`" so that cross-origin
         servers must explicitly opt-in to having their resources used as image
         resources.
       </aside>

--- a/index.html
+++ b/index.html
@@ -369,11 +369,11 @@
             <li>Set [=request/Client=] to the context object's [=relevant
             settings object=].
             </li>
-            <li>Set [=request/Mode=] to "[=cors=]".
-            </li>
           </ol>
         </li>
         <li>If |request|'s [=request/Client=] is null, throw a {{TypeError}}.
+        </li>
+        <li>Set |request|'s [=request/Mode=] to "[=cors=]".
         </li>
         <li>Perform a [=fetch=] using |request| and return the [=Response=].
         </li>

--- a/index.html
+++ b/index.html
@@ -354,10 +354,13 @@
       <p>
         The steps for <dfn data-export="">fetching an image resource</dfn> are
         given by the following algorithm. The algorithm takes an [=image
-        resource=] |image|, and an optional [=Request=] |request|. It returns a
+        resource=] |image|, an optional [=Request=] |request|, and an optional
+        [=request/mode=] |mode| (default "[=cors=]"). It returns a
         [=Response=].
       </p>
       <ol>
+        <li>[=Assert=]: |mode| is "[=cors=]" or "[=same-origin=]".
+        </li>
         <li>If |request| is `undefined`:
           <ol>
             <li>Set |request| to a new [=Request=].
@@ -371,9 +374,9 @@
             </li>
           </ol>
         </li>
-        <li>If |request|'s [=request/Client=] is null, throw a {{TypeError}}.
+        <li>[=Assert=]: |request|'s [=request/Client=] is not null.
         </li>
-        <li>Set |request|'s [=request/Mode=] to "[=cors=]".
+        <li>Set |request|'s [=request/Mode=] to |mode|.
         </li>
         <li>Perform a [=fetch=] using |request| and return the [=Response=].
         </li>


### PR DESCRIPTION
The "fetching an image resource" algorithm currently does not set a request mode, which defaults to `no-cors`. This means cross-origin servers don't need to opt-in to having their resources used as image resources.

Checking browser implementations:

- **Firefox**: explicitly sets `mode: "cors"` when fetching manifest icons.
- **Chrome**: uses `DownloadImageInFrame` through the document frame (mode handling is internal).
- **WebKit**: currently bypasses the document context entirely ([webkit.org/b/311872](https://bugs.webkit.org/show_bug.cgi?id=311872)).

With `no-cors`, a manifest author can reference cross-origin icon URLs that cause the user agent to make requests to servers that haven't opted in. While a simple GET still reaches the server regardless of mode, `cors` ensures the response is a network error without CORS headers, making the icon unusable. This disincentivizes using arbitrary third-party URLs as icon sources and is consistent with how `fetch()` itself defaults to `cors`.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/pull/50.html" title="Last updated on Jul 2, 2026, 12:42 PM UTC (e0139e6)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/50/81eab2c...e0139e6.html" title="Last updated on Jul 2, 2026, 12:42 PM UTC (e0139e6)">Diff</a>