### PR TITLE
chore: add pull request template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,19 @@
+Closes #???
+
+The following tasks have been completed:
+
+ * [ ] Modified Web platform tests (link to pull request)
+
+Implementation commitment (and no objections):
+
+ * [ ] WebKit (https://bugs.webkit.org/show_bug.cgi?id=)
+ * [ ] Chromium (https://bugs.chromium.org/p/chromium/issues/detail?id=)
+ * [ ] Gecko (https://bugzilla.mozilla.org/show_bug.cgi?id=)
+
+Documentation (new feature):
+
+ * [ ] Updated implementation report
+ * [ ] Pinged MDN
+ * [ ] Added example to README or spec
+
+For documentation, either create an [issue](https://github.com/mdn/content/issues) or pull request in [MDN's Content](https://github.com/mdn/content) repo  - providing as much information as you can. PR is prefered.


### PR DESCRIPTION
Adds a pull request template to help contributors provide implementation commitments, WPT links, and documentation updates. Copied from the Geolocation API repo.