### PR TITLE
Retire Diego González as editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,6 +18,7 @@
             company: "Microsoft Corporation",
             companyURL: "https://microsoft.com/",
             w3cid: 66757,
+            retiredDate: "2026-04-24",
           },
         ],
         formerEditors: [


### PR DESCRIPTION
Add `retiredDate` to Diego González's editor entry per ReSpec convention. He is no longer a Web Apps WG participant.


<!--
    This comment and the below content is programmatically generated.
    You may add a comma-separated list of anchors you'd like a
    direct link to below (e.g. #idl-serializers, #idl-sequence):

    Don't remove this comment or modify anything below this line.
    If you don't want a preview generated for this pull request,
    just replace the whole of this comment's content by "no preview"
    and remove what's below.
-->
***
<a href="https://pr-preview.s3.amazonaws.com/marcoscaceres/image-resource/pull/52.html" title="Last updated on Apr 24, 2026, 1:55 AM UTC (ce28721)">Preview</a> | <a href="https://pr-preview.s3.amazonaws.com/w3c/image-resource/52/81eab2c...marcoscaceres:ce28721.html" title="Last updated on Apr 24, 2026, 1:55 AM UTC (ce28721)">Diff</a>